### PR TITLE
Changes in featured block

### DIFF
--- a/blocks/featured-products/featured-products.js
+++ b/blocks/featured-products/featured-products.js
@@ -28,7 +28,7 @@ export default async function decorate(block) {
       const listItem = document.createElement('li');
       const anchor = document.createElement('a');
 
-      anchor.href = value && value.trim() !== '' ? value : '#';
+      anchor.href = value && value.trim() !== '' ? `${value}.html` : '#';
       anchor.textContent = key;
       anchor.target = '_blank';
 


### PR DESCRIPTION
Test URLs:

Before: https://main--sciex-eds--sciex-eds-nonprod.aem.live/
After: https://feature-related-resources--sciex-eds--sciex-eds-nonprod.aem.live/