### PR TITLE
Breadcrumb styling issue for mobile

### DIFF
--- a/blocks/button-text/_button-text.json
+++ b/blocks/button-text/_button-text.json
@@ -25,7 +25,7 @@
           "valueType": "string",
           "name": "buttonId",
           "label": "Button Id",
-          "value": "button-text"
+          "value": ""
         },
         {
          "component": "richtext",
@@ -37,13 +37,13 @@
           "component": "text",
           "name": "buttonText",
           "label": "Primary Button Text",
-          "value": "Download PDF"
+          "value": ""
         },
         {
           "component": "aem-content",
           "name": "buttonUrl",
           "label": "primary Button Url",
-          "value": "#"
+          "value": ""
 
         },
         {

--- a/component-models.json
+++ b/component-models.json
@@ -283,7 +283,7 @@
         "valueType": "string",
         "name": "buttonId",
         "label": "Button Id",
-        "value": "button-text"
+        "value": ""
       },
       {
         "component": "richtext",
@@ -295,13 +295,13 @@
         "component": "text",
         "name": "buttonText",
         "label": "Primary Button Text",
-        "value": "Download PDF"
+        "value": ""
       },
       {
         "component": "aem-content",
         "name": "buttonUrl",
         "label": "primary Button Url",
-        "value": "#"
+        "value": ""
       },
       {
         "component": "radio-group",


### PR DESCRIPTION
Test URLs:

Before: https://main--sciex-eds--sciex-eds-nonprod.aem.live/
After: https://feature-resources--sciex-eds--sciex-eds-nonprod.aem.live/