### PR TITLE
Removing default text for related-resources

### DIFF
--- a/blocks/sciex-related-resource/_sciex-related-resource.json
+++ b/blocks/sciex-related-resource/_sciex-related-resource.json
@@ -41,7 +41,7 @@
                 "valueType": "string",
                 "name": "heading",
                 "label": "Heading",
-                "value": "Related Resources"
+                "value": ""
             }
         ]
       },

--- a/component-models.json
+++ b/component-models.json
@@ -716,7 +716,7 @@
         "valueType": "string",
         "name": "heading",
         "label": "Heading",
-        "value": "Related Resources"
+        "value": ""
       }
     ]
   },


### PR DESCRIPTION
Test URLs:

Before: https://main--sciex-eds--sciex-eds-nonprod.aem.live/
After: https://feature-resources--sciex-eds--sciex-eds-nonprod.aem.live/