### PR TITLE
Alt fields added for blocks

### DIFF
--- a/blocks/searchresult/_searchresult.json
+++ b/blocks/searchresult/_searchresult.json
@@ -36,6 +36,13 @@
         },
         {
           "component": "text",
+          "valueType": "string",
+          "name": "imageAlt",
+          "label": "Alt",
+          "value": ""
+        },
+        {
+          "component": "text",
           "name": "text1",
           "value": "",
           "label": "No results text1",

--- a/blocks/split-video-text/_split-video-text.json
+++ b/blocks/split-video-text/_split-video-text.json
@@ -105,11 +105,25 @@
           "multi": false
         },
         {
+          "component": "text",
+          "valueType": "string",
+          "name": "videoAlt",
+          "label": "Video Alt Text",
+          "value": ""
+        },
+        {
           "component": "reference",
           "valueType": "string",
           "name": "videoThumbnail",
           "label": "Video Thumbnail Picker",
           "multi": false
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "videoThumbnailAlt",
+          "label": "Video Thumbnail Alt Text",
+          "value": ""
         }
       ]
     },

--- a/component-models.json
+++ b/component-models.json
@@ -1333,6 +1333,13 @@
       },
       {
         "component": "text",
+        "valueType": "string",
+        "name": "imageAlt",
+        "label": "Alt",
+        "value": ""
+      },
+      {
+        "component": "text",
         "name": "text1",
         "value": "",
         "label": "No results text1",
@@ -1499,11 +1506,25 @@
         "multi": false
       },
       {
+        "component": "text",
+        "valueType": "string",
+        "name": "videoAlt",
+        "label": "Video Alt Text",
+        "value": ""
+      },
+      {
         "component": "reference",
         "valueType": "string",
         "name": "videoThumbnail",
         "label": "Video Thumbnail Picker",
         "multi": false
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "videoThumbnailAlt",
+        "label": "Video Thumbnail Alt Text",
+        "value": ""
       }
     ]
   },


### PR DESCRIPTION
Test URLs:

Before: https://main--sciex-eds--sciex-eds-nonprod.aem.live/
After: https://feature-alt-image-video--sciex-eds--sciex-eds-nonprod.aem.live/